### PR TITLE
[WIP DO NOT MERGE] conditional transfer

### DIFF
--- a/modules/client/src/controllers/ConditionalTransferController.ts
+++ b/modules/client/src/controllers/ConditionalTransferController.ts
@@ -13,13 +13,11 @@ import { ConnextInternal } from "src";
 
 export class ConditionalTransferController extends AbstractController {
   private appId: string;
-  private myPublicIdentifier: string;
 
   private timeout: NodeJS.Timeout;
 
   public conditionalTransfer = async (params: ConditionalTransferParameters): Promise<NodeChannel> => {
     this.log.info(`ConditionalTransfer called with parameters: ${JSON.stringify(params)}`);
-    this.myPublicIdentifier = ConnextInternal.publicIdentifier;
 
     // convert params + validate
     const { recipient, amount, assetId, type, options } = convert.ConditionalTransferParameters("bignumber", params);

--- a/modules/client/src/controllers/ConditionalTransferController.ts
+++ b/modules/client/src/controllers/ConditionalTransferController.ts
@@ -1,0 +1,198 @@
+import { AppRegistry, convert, NodeChannel, ConditionalTransferParameters } from "@connext/types";
+import { RejectInstallVirtualMessage } from "@counterfactual/node";
+import { AppInstanceInfo, Node as NodeTypes } from "@counterfactual/types";
+import { constants } from "ethers";
+import { BigNumber } from "ethers/utils";
+
+import { delay } from "../lib/utils";
+import { invalidAddress, invalidXpub } from "../validation/addresses";
+import { falsy, notLessThanOrEqualTo } from "../validation/bn";
+
+import { AbstractController } from "./AbstractController";
+import { ConnextInternal } from "src";
+
+export class ConditionalTransferController extends AbstractController {
+  private appId: string;
+  private myPublicIdentifier: string;
+
+  private timeout: NodeJS.Timeout;
+
+  public conditionalTransfer = async (params: ConditionalTransferParameters): Promise<NodeChannel> => {
+    this.log.info(`ConditionalTransfer called with parameters: ${JSON.stringify(params)}`);
+    this.myPublicIdentifier = ConnextInternal.publicIdentifier;
+
+    // convert params + validate
+    const { recipient, amount, assetId, type, options } = convert.ConditionalTransferParameters("bignumber", params);
+    const invalid = await this.validate(recipient, amount, assetId);
+    if (invalid) {
+      throw new Error(invalid.toString());
+    }
+
+    // check that there is sufficient free balance for amount
+    const preTransferBal = (await this.connext.getFreeBalance())[
+      this.cfModule.ethFreeBalanceAddress
+    ];
+
+    // TODO: if the recipient is the node, use install instead of installVirtual
+
+    // get app definition from constants
+    // TODO: this should come from a db on the node
+    const appInfo = AppRegistry[this.connext.network.name].;
+
+    if (!appInfo) {
+      throw new Error("Could not find app in registry with supported network");
+    }
+
+    // TODO: check if recipient has a channel with the hub w/sufficient balance
+    // or if there is a route available through the node
+
+    // install the transfer application
+    try {
+      await this.transferAppInstalled(amount, recipient);
+    } catch (e) {
+      // TODO: can add more checks in `rejectInstall` but there is no
+      // way to check if the recipient is collateralized atm, so just
+      // assume this is the reason the install was rejected
+      throw new Error("Recipient online, but does not have sufficient collateral");
+    }
+
+    // update state
+    // TODO: listener for reject state?
+    await this.connext.takeAction(this.appId, {
+      finalize: false,
+      transferAmount: amount,
+    });
+
+    // finalize state + uninstall application
+    await this.finalizeAndUninstallApp(this.appId);
+
+    // sanity check, free balance decreased by payment amount
+    const postTransferBal = await this.connext.getFreeBalance();
+    const diff = preTransferBal.sub(postTransferBal[this.cfModule.ethFreeBalanceAddress]);
+    if (!diff.eq(amount)) {
+      this.log.info(
+        "Welp it appears the difference of the free balance before and after " +
+          "uninstalling is not what we expected......",
+      );
+    } else if (postTransferBal[this.cfModule.ethFreeBalanceAddress].gte(preTransferBal)) {
+      this.log.info(
+        "Free balance after transfer is gte free balance " +
+          "before transfer..... That's not great..",
+      );
+    }
+
+    const newState = await this.connext.getChannel();
+
+    // TODO: fix the state / types!!
+    return newState;
+  };
+
+  /////////////////////////////////
+  ////// PRIVATE METHODS
+  private validate = async (
+    recipient: string,
+    amount: BigNumber,
+    assetId: string,
+  ): Promise<undefined | string> => {
+    // check that there is sufficient free balance for amount
+    const freeBalance = await this.connext.getFreeBalance();
+    const preTransferBal = freeBalance[this.cfModule.ethFreeBalanceAddress];
+    const errs = [
+      invalidXpub(recipient),
+      invalidAddress(assetId),
+      notLessThanOrEqualTo(amount, preTransferBal),
+    ];
+    return errs ? errs.filter(falsy)[0] : undefined;
+  };
+
+  // TODO: fix type of data
+  private resolveInstallTransfer = (res: any, data: any): any => {
+    if (this.appId !== data.params.appInstanceId) {
+      return;
+    }
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+    }
+    res(data);
+    return data;
+  };
+
+  // TODO: fix types of data
+  private rejectInstallTransfer = (rej: any, data: RejectInstallVirtualMessage): any => {
+    // check app id
+    if (this.appId !== data.data.appInstanceId) {
+      return;
+    }
+
+    rej(`Install virtual rejected. Event data: ${JSON.stringify(data, null, 2)}`);
+    return data;
+  };
+
+  // creates a promise that is resolved once the app is installed
+  // and rejected if the virtual application is rejected
+  private transferAppInstalled = async (amount: BigNumber, recipient: string): Promise<any> => {
+    let boundResolve;
+    let boundReject;
+
+    const res = await this.connext.proposeInstallVirtualApp(
+      "EthUnidirectionalTransferApp",
+      amount,
+      recipient, // must be xpub
+    );
+    // set app instance id
+    this.appId = res.appInstanceId;
+
+    await new Promise((res, rej) => {
+      boundReject = this.rejectInstallTransfer.bind(null, rej);
+      boundResolve = this.resolveInstallTransfer.bind(null, res);
+      this.listener.on(NodeTypes.EventName.INSTALL_VIRTUAL, boundResolve);
+      this.listener.on(NodeTypes.EventName.REJECT_INSTALL_VIRTUAL, boundReject);
+      this.timeout = setTimeout(() => {
+        this.cleanupInstallListeners(boundResolve, boundReject);
+        boundReject({ data: { data: this.appId } });
+      }, 5000);
+    });
+
+    this.cleanupInstallListeners(boundResolve, boundReject);
+    return res.appInstanceId;
+  };
+
+  private cleanupInstallListeners = (boundResolve: any, boundReject: any): void => {
+    this.listener.removeListener(NodeTypes.EventName.INSTALL_VIRTUAL, boundResolve);
+    this.listener.removeListener(NodeTypes.EventName.REJECT_INSTALL_VIRTUAL, boundReject);
+  };
+
+  private finalizeAndUninstallApp = async (appId: string): Promise<void> => {
+    await this.connext.takeAction(appId, {
+      finalize: true,
+      transferAmount: constants.Zero,
+    });
+
+    await this.connext.uninstallVirtualApp(appId);
+    // TODO: cf does not emit uninstall virtual event on the node
+    // that has called this function but ALSO does not immediately
+    // uninstall the apps. This will be a problem when trying to
+    // display balances...
+    const openApps = await this.connext.getAppInstances();
+    this.log.info(`Open apps: ${openApps.length}`);
+    this.log.info(`AppIds: ${JSON.stringify(openApps.map(a => a.id))}`);
+
+    // adding a promise for now that polls app instances, but its not
+    // great and should be removed
+    await new Promise(async (res, rej) => {
+      const getAppIds = async (): Promise<string[]> => {
+        return (await this.connext.getAppInstances()).map((a: AppInstanceInfo) => a.id);
+      };
+      let retries = 0;
+      while ((await getAppIds()).indexOf(this.appId) !== -1 && retries <= 5) {
+        this.log.info("found app id in the open apps... retrying...");
+        await delay(500);
+        retries = retries + 1;
+      }
+
+      if (retries > 5) rej();
+
+      res();
+    });
+  };
+}

--- a/modules/client/src/controllers/TransferController.ts
+++ b/modules/client/src/controllers/TransferController.ts
@@ -1,7 +1,7 @@
 import { AppRegistry, convert, NodeChannel, TransferParameters } from "@connext/types";
 import { RejectInstallVirtualMessage } from "@counterfactual/node";
 import { AppInstanceInfo, Node as NodeTypes } from "@counterfactual/types";
-import { constants, Wallet } from "ethers";
+import { constants } from "ethers";
 import { BigNumber } from "ethers/utils";
 
 import { delay } from "../lib/utils";
@@ -11,6 +11,7 @@ import { falsy, notLessThanOrEqualTo } from "../validation/bn";
 import { AbstractController } from "./AbstractController";
 import { AddressZero, Zero } from "ethers/constants";
 import { fromExtendedKey } from "ethers/utils/hdnode";
+import { ConnextInternal } from "src";
 
 export class TransferController extends AbstractController {
   private appId: string;
@@ -18,9 +19,9 @@ export class TransferController extends AbstractController {
 
   private timeout: NodeJS.Timeout;
 
-  public transfer = async (params: TransferParameters, wallet: Wallet): Promise<NodeChannel> => {
+  public transfer = async (params: TransferParameters): Promise<NodeChannel> => {
     this.log.info(`Transfer called with parameters: ${JSON.stringify(params, null, 2)}`);
-    this.myPublicIdentifier = wallet.address
+    this.myPublicIdentifier = ConnextInternal.publicIdentifier;
 
     // convert params + validate
     const { recipient, amount, assetId } = convert.TransferParameters("bignumber", params);

--- a/modules/client/src/controllers/TransferController.ts
+++ b/modules/client/src/controllers/TransferController.ts
@@ -15,13 +15,11 @@ import { ConnextInternal } from "src";
 
 export class TransferController extends AbstractController {
   private appId: string;
-  private myPublicIdentifier: string;
 
   private timeout: NodeJS.Timeout;
 
   public transfer = async (params: TransferParameters): Promise<NodeChannel> => {
     this.log.info(`Transfer called with parameters: ${JSON.stringify(params, null, 2)}`);
-    this.myPublicIdentifier = ConnextInternal.publicIdentifier;
 
     // convert params + validate
     const { recipient, amount, assetId } = convert.TransferParameters("bignumber", params);
@@ -142,8 +140,7 @@ export class TransferController extends AbstractController {
         transfers: [
           {
             amount,
-            to: this.myPublicIdentifier,
-            // TODO: replace? fromExtendedKey(this.publicIdentifier).derivePath("0").address
+            to: fromExtendedKey(this.connext.publicIdentifier).derivePath("0").address
           },
           {
             amount: Zero,
@@ -151,7 +148,7 @@ export class TransferController extends AbstractController {
           },
         ],
       },
-      intermediaries: [AddressZero],
+      intermediaries: [this.connext.nodePublicIdentifier],
       myDeposit: amount,
       proposedToIdentifier: recipient,
     };

--- a/modules/types/src/index.ts
+++ b/modules/types/src/index.ts
@@ -68,7 +68,7 @@ export const AppRegistry: IAppRegistry = {
       asset: { assetType: 0 },
       initialStateFinalized: false,
       outcomeType: OutcomeType.TWO_PARTY_DYNAMIC_OUTCOME,
-      peerDeposit: constants.Zero, // TODO: include this?
+      peerDeposit: constants.Zero, // TODO: include this? @layne no, it's always zero for unidirectional - Arjun
       timeout: constants.Zero,
     },
   },
@@ -266,6 +266,12 @@ export type TransferParameters<T = string> = DepositParameters<T> & {
 };
 export type TransferParametersBigNumber = TransferParameters<BigNumber>;
 
+////// ConditionalTransfer types
+export type ConditionalTransferParameters<T = string> = TransferParameters<T> & {
+  type: string;
+  options?: any;
+}
+
 ////// Exchange types
 // TODO: would we ever want to pay people in the same app with multiple currencies?
 export interface ExchangeParameters<T = string> {
@@ -405,6 +411,23 @@ export function convertTransferParametersToAsset<To extends NumericTypeName>(
   };
 }
 
+//TODO: Is there any way to convert numbers in obj.options to BNs here?
+export function convertConditionalTransferParametersToAsset<To extends NumericTypeName>(
+  to: To,
+  obj: ConditionalTransferParameters<any>,
+): ConditionalTransferParameters<NumericTypes[To]> {
+  const asset: any = {
+    ...obj,
+  };
+  if (!asset.assetId) {
+    asset.assetId = constants.AddressZero;
+  }
+  return {
+    ...asset,
+    ...convertAssetAmount(to, asset),
+  };
+}
+
 export function convertWithdrawParametersToAsset<To extends NumericTypeName>(
   to: To,
   obj: WithdrawParameters<any>,
@@ -436,5 +459,6 @@ export const convert: any = {
   Multisig: convertMultisig,
   Transfer: convertAssetAmount,
   TransferParameters: convertTransferParametersToAsset,
+  ConditionalTransferParameters: convertConditionalTransferParametersToAsset,
   Withdraw: convertWithdrawParametersToAsset,
 };


### PR DESCRIPTION
Implements Conditional Transfer controller by:
- Updating types to include conditional transfer type and conversion fn
- Adding case by case logic for each different type of conditional transfer
- wiring up the controller to the rest of the client API
[AND] - generalizing low level `proposeInstallVirtual` to use CF node params (and updating corresponding fn in `TransferController` 

THIS PR IS A **WIP**

Open problems:
1) Is there a generalized way to do string->BN conversions in the `options` object on the conditional transfer type? (This would dramatically reduce overhead in adding new transfer types)
2) How can we handle uninstalling? Probably need another fn called `resolveCondition` to do this..?