### PR TITLE
Update payment-bot README.md

### DIFF
--- a/modules/payment-bot/README.md
+++ b/modules/payment-bot/README.md
@@ -6,7 +6,7 @@ Payment functionality is demonstrated by using two payment bots connected to an 
 
 ## Initial Setup
 All setup is from root of repository.
-* `make start` or `bash ops/start-dev kovan` to run Indra node locally on Ganache or Kovan.
+* `make start` or `bash ops/start-dev.sh kovan` to run Indra node locally on Ganache or Kovan.
 
 ## Bot Functionality
 The bot can be run with the following optional command line arguments:


### PR DESCRIPTION
Without the `.sh` file format it'd error out `bash: ops/start-dev: No such file or directory`